### PR TITLE
Add support for passing flags to C++ compiler

### DIFF
--- a/sqlines/makefile
+++ b/sqlines/makefile
@@ -1,2 +1,2 @@
 sqlines:
-	g++ applog.cpp file.cpp filelist.cpp main.cpp os.cpp parameters.cpp sqlines.cpp str.cpp ../sqlparser/sqlparser.a -o sqlines
+	g++ $(CXXFLAGS) applog.cpp file.cpp filelist.cpp main.cpp os.cpp parameters.cpp sqlines.cpp str.cpp ../sqlparser/sqlparser.a -o sqlines

--- a/sqlparser/makefile
+++ b/sqlparser/makefile
@@ -1,4 +1,4 @@
 
 sqlparser:
-	g++ -m32 -c dllmain.cpp cobol.cpp file.cpp clauses.cpp datatypes.cpp db2.cpp functions.cpp greenplum.cpp guess.cpp informix.cpp language.cpp mysql.cpp oracle.cpp postgresql.cpp select.cpp helpers.cpp patterns.cpp post.cpp procedures.cpp storage.cpp sqlparser.cpp sqlserver.cpp statements.cpp teradata.cpp token.cpp 
+	g++ $(CXXFLAGS) -c dllmain.cpp cobol.cpp file.cpp clauses.cpp datatypes.cpp db2.cpp functions.cpp greenplum.cpp guess.cpp informix.cpp language.cpp mysql.cpp oracle.cpp postgresql.cpp select.cpp helpers.cpp patterns.cpp post.cpp procedures.cpp storage.cpp sqlparser.cpp sqlserver.cpp statements.cpp teradata.cpp token.cpp 
 	ar rcs sqlparser.a dllmain.o cobol.o file.o clauses.o datatypes.o db2.o functions.o greenplum.o guess.o informix.o language.o mysql.o oracle.o postgresql.o select.o helpers.o patterns.o post.o procedures.o storage.o sqlparser.o sqlserver.o statements.o teradata.o token.o


### PR DESCRIPTION
This is only done in sqlparser/ and sqlines/ dirs, as they were
the only place I needed for now.

Example usage:

    make CXXFLAGS="-fpermissive -g"

NOTE: -fpermissive is needed with gcc 7.2.0 or build fails